### PR TITLE
[codex] fix home page text contrast

### DIFF
--- a/src/components/blog-list/BlogList.module.scss
+++ b/src/components/blog-list/BlogList.module.scss
@@ -98,7 +98,7 @@
 }
 
 .date {
-  color: rgba(255, 255, 255, 0.42);
+  color: rgba(255, 255, 255, 0.5);
   font-family: var(--font-myriad-md), Arial, sans-serif;
   font-size: 11px;
   line-height: 1.2;

--- a/src/components/footer/Footer.module.scss
+++ b/src/components/footer/Footer.module.scss
@@ -38,14 +38,14 @@
 }
 
 .copyright {
-  color: rgba(255, 255, 255, 0.4);
+  color: rgba(255, 255, 255, 0.5);
   font-size: 13px;
   margin: 0;
   font-family: var(--font-myriad), Arial, sans-serif;
 }
 
 .footerLink {
-  color: rgba(255, 255, 255, 0.4);
+  color: rgba(255, 255, 255, 0.5);
   font-size: 13px;
   text-decoration: none;
   font-family: var(--font-myriad), Arial, sans-serif;

--- a/src/components/header/Header.module.scss
+++ b/src/components/header/Header.module.scss
@@ -35,7 +35,7 @@
 .meta {
   margin: 0;
   max-width: 26ch;
-  color: rgba(255, 255, 255, 0.4);
+  color: rgba(255, 255, 255, 0.5);
   font-size: 12px;
   line-height: 1.4;
   text-align: right;


### PR DESCRIPTION
## Summary

Fixes the home page accessibility contrast issue by raising only the muted small-text foreground opacity values that were below WCAG contrast requirements.

## Root Cause

Header meta text, blog post dates, and footer text used `rgba(255, 255, 255, 0.4)` / `0.42` on a near-black background, which produced insufficient contrast for small text.

## Changes

- Increased header meta text opacity to `0.5`.
- Increased blog post date text opacity to `0.5`.
- Increased footer copyright/link text opacity to `0.5`.

## Validation

- `npm run lint`
- `npm run build`
- Manual contrast calculation confirms the updated muted text is above 4.5:1 on the relevant dark backgrounds.