### PR TITLE
[codex] Remove legacy module polyfills

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -39,6 +39,18 @@ const nextConfig = {
 			},
 		];
 	},
+	webpack(config, { isServer }) {
+		if (!isServer) {
+			config.resolve.alias = {
+				...config.resolve.alias,
+				"../build/polyfills/polyfill-module": require.resolve(
+					"./src/polyfills/modern-browser-only.js",
+				),
+			};
+		}
+
+		return config;
+	},
 };
 
 module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -29,12 +29,14 @@
 		"start": "next start"
 	},
 	"browserslist": [
-		"chrome >= 92",
-		"firefox >= 90",
-		"safari >= 14.1",
-		"edge >= 92",
+		"chrome >= 120",
+		"edge >= 120",
+		"firefox >= 115",
+		"and_chr >= 120",
+		"and_ff >= 115",
+		"safari >= 17",
+		"ios_saf >= 17",
 		"not dead",
-		"not ie <= 11",
 		"not op_mini all"
 	]
 }

--- a/src/polyfills/modern-browser-only.js
+++ b/src/polyfills/modern-browser-only.js
@@ -1,0 +1,2 @@
+// Intentionally empty: this site targets modern browsers that already provide
+// the baseline APIs Next's default module polyfill checks for.


### PR DESCRIPTION
## What changed

- Replaced Next's client polyfill-module import with an intentionally empty modern-browser module.
- Tightened the documented Browserslist targets to modern browsers that support the baseline APIs natively.

## Why

Lighthouse reported about 12 KiB of legacy JavaScript in the shared app runtime chunk from Next's module polyfill checks. This site is targeting modern browsers, so carrying those runtime checks in the module bundle is unnecessary.

## Validation

- npm run lint
- npm run format:check
- npm run build
- Verified the production 794-*.js chunk no longer contains the reported shim signatures.